### PR TITLE
Error handling

### DIFF
--- a/column.go
+++ b/column.go
@@ -118,13 +118,14 @@ func init() {
 func RegisterColumnType(name ColumnType, serier ColumnSerier) error {
 	name = ColumnType(strings.TrimSpace(string(name)))
 	if len(name) == 0 {
-		return errors.New("empty name")
+		return ErrEmptyName
 	}
 	if serier == nil {
-		return errors.New("nil factory")
+		return ErrNilFactory
 	}
 	if _, ok := ctypes[name]; ok {
-		return errors.Errorf("type '%s' already exists", name)
+		err := errors.Errorf("type '%s' already exists", name)
+		return errors.Wrap(err, ErrTypeAlreadyExists.Error())
 	}
 	ctypes[name] = serier
 	return nil
@@ -144,7 +145,8 @@ func newColumnSerie(ctyp ColumnType, options ColumnOptions) (serie.Serie, error)
 	if s, ok := ctypes[ctyp]; ok {
 		return s(options), nil
 	}
-	return nil, errors.Errorf("unknown column type '%s'", ctyp)
+	err := errors.Errorf("unknown column type '%s'", ctyp)
+	return nil, errors.Wrap(err, ErrUnknownColumnType.Error())
 }
 
 // Column describes a column in our datatable

--- a/concat.go
+++ b/concat.go
@@ -1,7 +1,5 @@
 package datatable
 
-import "github.com/pkg/errors"
-
 // Concat datatables
 func (left *DataTable) Concat(table ...*DataTable) (*DataTable, error) {
 	out := left.EmptyCopy()
@@ -57,7 +55,7 @@ func (left *DataTable) Concat(table ...*DataTable) (*DataTable, error) {
 func Concat(tables []*DataTable) (*DataTable, error) {
 	switch len(tables) {
 	case 0:
-		return nil, errors.New("no tables")
+		return nil, ErrNoTables
 	case 1:
 		return tables[0].Concat()
 	default:

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,71 @@
+package datatable
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Errors in import/csv
+var (
+	ErrOpenFile           = errors.New("open file")
+	ErrCantReadHeaders    = errors.New("can't read headers")
+	ErrReadingLine        = errors.New("could not read line")
+	ErrNilDatas           = errors.New("nil datas")
+	ErrWrongNumberOfTypes = errors.New("expected different number of types")
+	ErrAddingColumn       = errors.New("could not add column with given type")
+)
+
+// Errors in aggregate.go
+var (
+	ErrNoGroupBy      = errors.New("no groupby")
+	ErrNoGroups       = errors.New("no groups")
+	ErrNilDatatable   = errors.New("nil datatable")
+	ErrColumnNotFound = errors.New("column not found")
+	ErrUnknownAgg     = errors.New("unknown agg")
+	ErrCantAddColumn  = errors.New("can't add column")
+)
+
+// Errors in column.go
+var (
+	ErrEmptyName         = errors.New("empty name")
+	ErrNilFactory        = errors.New("nil factory")
+	ErrTypeAlreadyExists = errors.New("type already exists")
+	ErrUnknownColumnType = errors.New("unknown column type")
+)
+
+// Errors in concat.go
+var (
+	ErrNoTables = errors.New("no tables")
+)
+
+// Errors in eval_expr
+var (
+	ErrEvaluateExprSizeMismatch = errors.New("size mismatch")
+)
+
+// Errors in join.go
+var (
+	ErrNilOutputDatatable  = errors.New("nil output datatable")
+	ErrNoOutput            = errors.New("no output")
+	ErrNilTable            = errors.New("table is nil")
+	ErrNotEnoughDatatables = errors.New("not enough datatables")
+	ErrNoOnClauses         = errors.New("no on clauses")
+	ErrOnClauseIsNil       = errors.New("on clause is nil")
+	ErrUnknownMode         = errors.New("unknown mode")
+)
+
+// Errors in mutate_column.go
+var (
+	ErrNilColumn           = errors.New("nil column")
+	ErrNilColumnName       = errors.New("nil column name")
+	ErrNilColumnType       = errors.New("nil column type")
+	ErrColumnAlreadyExists = errors.New("column already exists")
+	ErrFormulaeSyntax      = errors.New("formulae syntax")
+	ErrNilSerie            = errors.New("nil serie")
+	ErrCreateSerie         = errors.New("create serie")
+)
+
+// Errors in mutate_rows.go
+var (
+	ErrLengthMismatch = errors.New("length mismatch")
+	ErrUpdateRow      = errors.New("update row")
+)

--- a/eval_expr.go
+++ b/eval_expr.go
@@ -47,7 +47,8 @@ func (t *DataTable) evaluateExpressions() error {
 			la := len(arr)
 
 			if t.nrows != ls || la != ls {
-				return errors.Errorf("evaluate expr : size mismatch %d vs %d", la, ls)
+				err := errors.Errorf("evaluate expr : size mismatch %d vs %d", la, ls)
+				return errors.Wrap(err, ErrEvaluateExprSizeMismatch.Error())
 			}
 
 			for i := 0; i < t.nrows; i++ {

--- a/mutate_row.go
+++ b/mutate_row.go
@@ -33,7 +33,8 @@ func (t *DataTable) Append(row ...Row) {
 // AppendRow creates a new row and append cells to this row
 func (t *DataTable) AppendRow(v ...interface{}) error {
 	if len(v) != len(t.cols) {
-		return errors.Errorf("length mismatch: expected %d elements, values have %d elements", len(t.cols), len(v))
+		err := errors.Errorf("length mismatch: expected %d elements, values have %d elements", len(t.cols), len(v))
+		return errors.Wrap(err, ErrLengthMismatch.Error())
 	}
 
 	for i, col := range t.cols {
@@ -77,12 +78,14 @@ func (t *DataTable) Update(at int, row Row) error {
 		cell, ok := row[col.name]
 		if ok {
 			if err := col.serie.Set(at, cell); err != nil {
-				return errors.Wrapf(err, "col %s", col.name)
+				err := errors.Wrapf(err, "col %s", col.name)
+				return errors.Wrap(err, ErrUpdateRow.Error())
 			}
 			continue
 		}
 		if err := col.serie.Set(at, nil); err != nil {
-			return errors.Wrapf(err, "col %s", col.name)
+			err := errors.Wrapf(err, "col %s", col.name)
+			return errors.Wrap(err, ErrUpdateRow.Error())
 		}
 	}
 

--- a/serie/errors.go
+++ b/serie/errors.go
@@ -1,0 +1,15 @@
+package serie
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Errors in mutate.go
+var (
+	ErrOutOfRange                      = errors.New("out of range")
+	ErrCantFlattenSliceWithSet         = errors.New("can't flatten slice with set")
+	ErrGrowSizeMustBeStriclyPositive   = errors.New("grow: size must be > 0")
+	ErrShrinkSizeMustBeStriclyPositive = errors.New("shrink: size must be > 0")
+	ErrShrinkSizeMustBeLesserThanLen   = errors.New("shrink: size must be < len")
+	ErrConcatTypeMismatch              = errors.New("concat: type mismatch")
+)


### PR DESCRIPTION
Hi!

I have changed hardcoded errors to either directly return one error from a list of global errors, or by wrapping the err with one error from the list. The goal is to be able to `errors.Is(err, datatable.ErrX)` on an error to determine programmatically what caused the problem without the need for a human to understand and contextualize it.